### PR TITLE
JUnit and Mockito Test

### DIFF
--- a/src/main/java/com/endava/internship/mocking/repository/InMemPaymentRepository.java
+++ b/src/main/java/com/endava/internship/mocking/repository/InMemPaymentRepository.java
@@ -46,7 +46,7 @@ public class InMemPaymentRepository implements PaymentRepository {
         }
 
         if (nonNull(payment.getPaymentId()) && findById(payment.getPaymentId()).isPresent()) {
-            throw new IllegalArgumentException("Payment with id " + payment.getPaymentId() + "already saved");
+            throw new IllegalArgumentException("Payment with id " + payment.getPaymentId() + " already saved");
         }
 
         paymentMap.put(payment.getPaymentId(), Payment.copyOf(payment));

--- a/src/main/java/com/endava/internship/mocking/service/PaymentService.java
+++ b/src/main/java/com/endava/internship/mocking/service/PaymentService.java
@@ -36,7 +36,6 @@ public class PaymentService {
         return paymentRepository.save(payment);
     }
 
-
     public Payment editPaymentMessage(UUID paymentId, String newMessage) {
         validationService.validatePaymentId(paymentId);
         validationService.validateMessage(newMessage);

--- a/src/main/java/com/endava/internship/mocking/service/PaymentService.java
+++ b/src/main/java/com/endava/internship/mocking/service/PaymentService.java
@@ -36,6 +36,7 @@ public class PaymentService {
         return paymentRepository.save(payment);
     }
 
+
     public Payment editPaymentMessage(UUID paymentId, String newMessage) {
         validationService.validatePaymentId(paymentId);
         validationService.validateMessage(newMessage);

--- a/src/test/java/com/endava/internship/mocking/repository/InMemPaymentRepositoryTest.java
+++ b/src/test/java/com/endava/internship/mocking/repository/InMemPaymentRepositoryTest.java
@@ -1,0 +1,78 @@
+package com.endava.internship.mocking.repository;
+
+import com.endava.internship.mocking.model.Payment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class InMemPaymentRepositoryTest {
+
+    InMemPaymentRepository inMemPaymentRepository;
+    Payment payment;
+    Payment payment1;
+
+    @BeforeEach
+    void setUp(){
+        inMemPaymentRepository = new InMemPaymentRepository();
+        payment = new Payment(33, 555.00, "Insert amount");
+        payment1 = new Payment(44, 666.00, "Insert amount");
+        inMemPaymentRepository.save(payment);
+    }
+
+    @Test
+    void findByIdShouldThrowIllegalArgumentExceptionIfTheUUIDIsNull() {
+        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
+                () -> inMemPaymentRepository.findById(null));
+        assertEquals(exceptionThatWasThrown.getMessage(), "Payment id must not be null");
+    }
+
+    @Test
+    void findByIdShouldReturnPaymentById() {
+        assertEquals(payment, inMemPaymentRepository.findById(payment.getPaymentId()).get());
+    }
+
+    @Test
+    void findAllShouldReturnAllPayments() {
+        inMemPaymentRepository.save(payment1);
+        List<Payment> paymentList = new ArrayList<>();
+        paymentList.add(payment);
+        paymentList.add(payment1);
+
+        assertThat(paymentList).hasSameElementsAs(inMemPaymentRepository.findAll());
+    }
+
+    @Test
+    void saveShouldThrowIllegalArgumentExceptionIfThePaymentIsNull() {
+        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
+                () -> inMemPaymentRepository.save(null));
+        assertEquals(exceptionThatWasThrown.getMessage(), "Payment must not be null");
+    }
+    @Test
+    void saveShouldThrowIllegalArgumentExceptionIfThePaymentIsAlreadySaved() {
+        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
+                () -> inMemPaymentRepository.save(payment));
+        assertEquals(exceptionThatWasThrown.getMessage(), "Payment with id " + payment.getPaymentId() + "already saved");
+    }
+    @Test
+    void saveShouldReturnSavedPayment() {
+        assertEquals(payment1, inMemPaymentRepository.save(payment1));
+    }
+
+    @Test
+    void editMessageShouldThrowNoSuchElementExceptionIfThePaymentIsNull() {
+        Throwable exceptionThatWasThrown = assertThrows(NoSuchElementException.class,
+                () -> inMemPaymentRepository.editMessage(payment1.getPaymentId(),"The payment was canceled"));
+        assertEquals(exceptionThatWasThrown.getMessage(), "Payment with id " + payment1.getPaymentId() + " not found");
+    }
+    @Test
+    void editMessageShouldSetNewMessage() {
+        Payment paymenttest = inMemPaymentRepository.editMessage(payment.getPaymentId(),"The payment was canceled");
+        assertEquals("The payment was canceled", paymenttest.getMessage());
+    }
+}

--- a/src/test/java/com/endava/internship/mocking/repository/InMemPaymentRepositoryTest.java
+++ b/src/test/java/com/endava/internship/mocking/repository/InMemPaymentRepositoryTest.java
@@ -49,7 +49,7 @@ class InMemPaymentRepositoryTest {
     }
 
     @Test
-    void shouldThrowIllegalArgumentExceptionIfThePaymentIsNull() {
+    void shouldThrowIllegalArgumentExceptionIfThePaymentToSaveIsNull() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> paymentRepository.save(null))
                 .withMessage("Payment must not be null");
@@ -69,7 +69,7 @@ class InMemPaymentRepositoryTest {
     }
 
     @Test
-    void shouldThrowNoSuchElementExceptionIfThePaymentIsNull() {
+    void shouldThrowNoSuchElementExceptionIfThePaymentExists() {
         assertThatExceptionOfType(NoSuchElementException.class)
                 .isThrownBy(() -> paymentRepository.editMessage(payment2.getPaymentId(), "The payment was canceled"))
                 .withMessage("Payment with id " + payment2.getPaymentId() + " not found");

--- a/src/test/java/com/endava/internship/mocking/repository/InMemPaymentRepositoryTest.java
+++ b/src/test/java/com/endava/internship/mocking/repository/InMemPaymentRepositoryTest.java
@@ -4,9 +4,8 @@ import com.endava.internship.mocking.model.Payment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -14,62 +13,74 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class InMemPaymentRepositoryTest {
 
-    PaymentRepository inMemPaymentRepository;
+    PaymentRepository paymentRepository;
+
     Payment payment;
+
     Payment payment1;
 
+    Payment payment2;
+
     @BeforeEach
-    void setUp(){
-        inMemPaymentRepository = new InMemPaymentRepository();
+    void setUp() {
+        paymentRepository = new InMemPaymentRepository();
         payment = new Payment(33, 555.00, "Insert amount");
         payment1 = new Payment(44, 666.00, "Insert amount");
-        inMemPaymentRepository.save(payment);
-        inMemPaymentRepository.save(payment1);
+        payment2 = new Payment(55, 777.00, "Insert amount");
+        paymentRepository.save(payment);
+        paymentRepository.save(payment1);
     }
 
     @Test
-    void findByIdShouldThrowIllegalArgumentExceptionIfTheUUIDIsNull() {
+    void shouldThrowIllegalArgumentExceptionIfTheUUIDIsNull() {
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> inMemPaymentRepository.findById(null))
+                .isThrownBy(() -> paymentRepository.findById(null))
                 .withMessage("Payment id must not be null");
     }
 
     @Test
-    void findByIdShouldReturnPaymentById() {
-        assertEquals(payment, inMemPaymentRepository.findById(payment.getPaymentId()).get());
+    void shouldReturnPaymentById() {
+        assertEquals(Optional.of(payment), paymentRepository.findById(payment.getPaymentId()));
     }
 
     @Test
-    void findAllShouldReturnAllPayments() {
-        assertThat(inMemPaymentRepository.findAll()).containsExactlyInAnyOrder(payment, payment1);
+    void shouldReturnAllPayments() {
+        assertThat(paymentRepository.findAll()).containsExactlyInAnyOrder(payment, payment1);
     }
 
     @Test
-    void saveShouldThrowIllegalArgumentExceptionIfThePaymentIsNull() {
-        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
-                () -> inMemPaymentRepository.save(null));
-        assertEquals(exceptionThatWasThrown.getMessage(), "Payment must not be null");
-    }
-    @Test
-    void saveShouldThrowIllegalArgumentExceptionIfThePaymentIsAlreadySaved() {
-        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
-                () -> inMemPaymentRepository.save(payment));
-        assertEquals(exceptionThatWasThrown.getMessage(), "Payment with id " + payment.getPaymentId() + "already saved");
-    }
-    @Test
-    void saveShouldReturnSavedPayment() {
-        assertEquals(payment1, inMemPaymentRepository.save(payment1));
+    void shouldThrowIllegalArgumentExceptionIfThePaymentIsNull() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> paymentRepository.save(null))
+                .withMessage("Payment must not be null");
+
     }
 
     @Test
-    void editMessageShouldThrowNoSuchElementExceptionIfThePaymentIsNull() {
-        Throwable exceptionThatWasThrown = assertThrows(NoSuchElementException.class,
-                () -> inMemPaymentRepository.editMessage(payment1.getPaymentId(),"The payment was canceled"));
-        assertEquals(exceptionThatWasThrown.getMessage(), "Payment with id " + payment1.getPaymentId() + " not found");
+    void shouldThrowIllegalArgumentExceptionIfThePaymentIsAlreadySaved() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> paymentRepository.save(payment))
+                .withMessage("Payment with id " + payment.getPaymentId() + " already saved");
     }
+
     @Test
-    void editMessageShouldSetNewMessage() {
-        Payment paymenttest = inMemPaymentRepository.editMessage(payment.getPaymentId(),"The payment was canceled");
-        assertEquals("The payment was canceled", paymenttest.getMessage());
+    void shouldReturnSavedPayment() {
+        assertEquals(payment2, paymentRepository.save(payment2));
+    }
+
+    @Test
+    void shouldThrowNoSuchElementExceptionIfThePaymentIsNull() {
+        assertThatExceptionOfType(NoSuchElementException.class)
+                .isThrownBy(() -> paymentRepository.editMessage(payment2.getPaymentId(), "The payment was canceled"))
+                .withMessage("Payment with id " + payment2.getPaymentId() + " not found");
+
+    }
+
+    @Test
+    void shouldSetNewMessage() {
+        String expectedMessage = "The payment was canceled";
+        Payment editedPayment = paymentRepository.editMessage(payment.getPaymentId(), "The payment was canceled");
+
+        assertEquals(expectedMessage, editedPayment.getMessage());
     }
 }

--- a/src/test/java/com/endava/internship/mocking/repository/InMemPaymentRepositoryTest.java
+++ b/src/test/java/com/endava/internship/mocking/repository/InMemPaymentRepositoryTest.java
@@ -9,11 +9,12 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.*;
 
 class InMemPaymentRepositoryTest {
 
-    InMemPaymentRepository inMemPaymentRepository;
+    PaymentRepository inMemPaymentRepository;
     Payment payment;
     Payment payment1;
 
@@ -23,13 +24,14 @@ class InMemPaymentRepositoryTest {
         payment = new Payment(33, 555.00, "Insert amount");
         payment1 = new Payment(44, 666.00, "Insert amount");
         inMemPaymentRepository.save(payment);
+        inMemPaymentRepository.save(payment1);
     }
 
     @Test
     void findByIdShouldThrowIllegalArgumentExceptionIfTheUUIDIsNull() {
-        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
-                () -> inMemPaymentRepository.findById(null));
-        assertEquals(exceptionThatWasThrown.getMessage(), "Payment id must not be null");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> inMemPaymentRepository.findById(null))
+                .withMessage("Payment id must not be null");
     }
 
     @Test
@@ -39,12 +41,7 @@ class InMemPaymentRepositoryTest {
 
     @Test
     void findAllShouldReturnAllPayments() {
-        inMemPaymentRepository.save(payment1);
-        List<Payment> paymentList = new ArrayList<>();
-        paymentList.add(payment);
-        paymentList.add(payment1);
-
-        assertThat(paymentList).hasSameElementsAs(inMemPaymentRepository.findAll());
+        assertThat(inMemPaymentRepository.findAll()).containsExactlyInAnyOrder(payment, payment1);
     }
 
     @Test

--- a/src/test/java/com/endava/internship/mocking/service/BasicValidationServiceTest.java
+++ b/src/test/java/com/endava/internship/mocking/service/BasicValidationServiceTest.java
@@ -1,0 +1,78 @@
+package com.endava.internship.mocking.service;
+
+import com.endava.internship.mocking.model.Status;
+import com.endava.internship.mocking.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BasicValidationServiceTest {
+    BasicValidationService basicValidationService;
+
+    @BeforeEach
+    void setUp() {
+        basicValidationService = new BasicValidationService();
+    }
+
+    @Test
+    void validateAmountShouldThrowIllegalArgumentExceptionIfTheParameterIsNull() {
+        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
+                () -> basicValidationService.validateAmount(null));
+        assertEquals(exceptionThatWasThrown.getMessage(), "Amount must not be null");
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {0.00, -5.00})
+    void validateAmountShouldThrowIllegalArgumentExceptionIfTheParameterLessOrEqualsToZero(Double amount) {
+        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
+                () -> basicValidationService.validateAmount(amount));
+        assertEquals(exceptionThatWasThrown.getMessage(), "Amount must be greater than 0");
+    }
+
+    @Test
+    void validatePaymentIdShouldThrowIllegalArgumentExceptionIfTheParameterIsNull() {
+        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
+                () -> basicValidationService.validatePaymentId(null));
+        assertEquals(exceptionThatWasThrown.getMessage(), "Payment id must not be null");
+    }
+
+    @Test
+    void validateUserIdShouldThrowIllegalArgumentExceptionIfTheParameterIsNull() {
+        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
+                () -> basicValidationService.validateUserId(null));
+        assertEquals(exceptionThatWasThrown.getMessage(), "User id must not be null");
+    }
+
+    @Test
+    void validateUserShouldThrowIllegalArgumentExceptionIfTheUserIsInactive() {
+        User user = new User(11, "Ben", Status.INACTIVE);
+        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
+                () -> basicValidationService.validateUser(user));
+        assertEquals(exceptionThatWasThrown.getMessage(), "User with id " + user.getId() + " not in ACTIVE status");
+    }
+
+    @Test
+    void validateMessageShouldThrowIllegalArgumentExceptionIfTheParameterIsNull() {
+        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
+                () -> basicValidationService.validateMessage(null));
+        assertEquals(exceptionThatWasThrown.getMessage(), "Payment message must not be null");
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/test/java/com/endava/internship/mocking/service/BasicValidationServiceTest.java
+++ b/src/test/java/com/endava/internship/mocking/service/BasicValidationServiceTest.java
@@ -6,15 +6,27 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class BasicValidationServiceTest {
-    BasicValidationService basicValidationService;
+
+    BasicValidationService mockBasicValidationService;
+    ValidationService basicValidationService;
 
     @BeforeEach
     void setUp() {
+        mockBasicValidationService = mock(BasicValidationService.class);
         basicValidationService = new BasicValidationService();
+    }
+
+    @Test
+    void validateAmountShouldCheckSuccessOfValidationOfAmount() {
+        mockBasicValidationService.validateAmount(333.00);
+        verify(mockBasicValidationService, times(1)).validateAmount(333.00);
     }
 
     @Test
@@ -33,6 +45,13 @@ class BasicValidationServiceTest {
     }
 
     @Test
+    void validatePaymentIdShouldCheckSuccessOfValidationOfPaymentId() {
+        mockBasicValidationService.validatePaymentId(UUID.randomUUID());
+        ArgumentCaptor<UUID> argumentCaptor = ArgumentCaptor.forClass(UUID.class);
+        verify(mockBasicValidationService, times(1)).validatePaymentId(argumentCaptor.capture());
+    }
+
+    @Test
     void validatePaymentIdShouldThrowIllegalArgumentExceptionIfTheParameterIsNull() {
         Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
                 () -> basicValidationService.validatePaymentId(null));
@@ -40,10 +59,23 @@ class BasicValidationServiceTest {
     }
 
     @Test
+    void validateUserIdShouldCheckSuccessOfValidationOfUserId() {
+        mockBasicValidationService.validateUserId(11);
+        verify(mockBasicValidationService, times(1)).validateUserId(11);
+    }
+
+    @Test
     void validateUserIdShouldThrowIllegalArgumentExceptionIfTheParameterIsNull() {
         Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
                 () -> basicValidationService.validateUserId(null));
         assertEquals(exceptionThatWasThrown.getMessage(), "User id must not be null");
+    }
+
+    @Test
+    void validateUserShouldCheckSuccessOfValidationOfUser() {
+        User user = new User(11, "Ben", Status.ACTIVE);
+        mockBasicValidationService.validateUser(user);
+        verify(mockBasicValidationService, times(1)).validateUser(user);
     }
 
     @Test
@@ -55,24 +87,15 @@ class BasicValidationServiceTest {
     }
 
     @Test
+    void validateMessageShouldCheckSuccessOfValidationOfMessage() {
+        mockBasicValidationService.validateMessage("hello");
+        verify(mockBasicValidationService, times(1)).validateMessage("hello");
+    }
+
+    @Test
     void validateMessageShouldThrowIllegalArgumentExceptionIfTheParameterIsNull() {
         Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
                 () -> basicValidationService.validateMessage(null));
         assertEquals(exceptionThatWasThrown.getMessage(), "Payment message must not be null");
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/test/java/com/endava/internship/mocking/service/BasicValidationServiceTest.java
+++ b/src/test/java/com/endava/internship/mocking/service/BasicValidationServiceTest.java
@@ -6,96 +6,88 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
+
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 class BasicValidationServiceTest {
 
-    BasicValidationService mockBasicValidationService;
-    ValidationService basicValidationService;
+    ValidationService validationService;
 
     @BeforeEach
     void setUp() {
-        mockBasicValidationService = mock(BasicValidationService.class);
-        basicValidationService = new BasicValidationService();
+        validationService = new BasicValidationService();
     }
 
     @Test
-    void validateAmountShouldCheckSuccessOfValidationOfAmount() {
-        mockBasicValidationService.validateAmount(333.00);
-        verify(mockBasicValidationService, times(1)).validateAmount(333.00);
+    void shouldAcceptTheAmount() {
+        assertDoesNotThrow(() -> validationService.validateAmount(55.00));
     }
 
     @Test
-    void validateAmountShouldThrowIllegalArgumentExceptionIfTheParameterIsNull() {
-        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
-                () -> basicValidationService.validateAmount(null));
-        assertEquals(exceptionThatWasThrown.getMessage(), "Amount must not be null");
+    void shouldThrowIllegalArgumentExceptionIfTheParameterIsNull() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> validationService.validateAmount(null))
+                .withMessage("Amount must not be null");
     }
 
     @ParameterizedTest
     @ValueSource(doubles = {0.00, -5.00})
-    void validateAmountShouldThrowIllegalArgumentExceptionIfTheParameterLessOrEqualsToZero(Double amount) {
-        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
-                () -> basicValidationService.validateAmount(amount));
-        assertEquals(exceptionThatWasThrown.getMessage(), "Amount must be greater than 0");
+    void shouldThrowIllegalArgumentExceptionIfTheParameterLessOrEqualsToZero(Double amount) {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> validationService.validateAmount(amount))
+                .withMessage("Amount must be greater than 0");
     }
 
     @Test
-    void validatePaymentIdShouldCheckSuccessOfValidationOfPaymentId() {
-        mockBasicValidationService.validatePaymentId(UUID.randomUUID());
-        ArgumentCaptor<UUID> argumentCaptor = ArgumentCaptor.forClass(UUID.class);
-        verify(mockBasicValidationService, times(1)).validatePaymentId(argumentCaptor.capture());
+    void shouldAcceptPaymentId() {
+        assertDoesNotThrow(() -> validationService.validatePaymentId(UUID.randomUUID()));
     }
 
     @Test
-    void validatePaymentIdShouldThrowIllegalArgumentExceptionIfTheParameterIsNull() {
-        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
-                () -> basicValidationService.validatePaymentId(null));
-        assertEquals(exceptionThatWasThrown.getMessage(), "Payment id must not be null");
+    void shouldThrowIllegalArgumentExceptionIfPaymentIdIsNull() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> validationService.validatePaymentId(null))
+                .withMessage("Payment id must not be null");
     }
 
     @Test
-    void validateUserIdShouldCheckSuccessOfValidationOfUserId() {
-        mockBasicValidationService.validateUserId(11);
-        verify(mockBasicValidationService, times(1)).validateUserId(11);
+    void shouldAcceptUserId() {
+        assertDoesNotThrow(() -> validationService.validateUserId(11));
     }
 
     @Test
-    void validateUserIdShouldThrowIllegalArgumentExceptionIfTheParameterIsNull() {
-        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
-                () -> basicValidationService.validateUserId(null));
-        assertEquals(exceptionThatWasThrown.getMessage(), "User id must not be null");
+    void shouldThrowIllegalArgumentExceptionIfUserIsNull() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> validationService.validateUserId(null))
+                .withMessage("User id must not be null");
     }
 
     @Test
-    void validateUserShouldCheckSuccessOfValidationOfUser() {
-        User user = new User(11, "Ben", Status.ACTIVE);
-        mockBasicValidationService.validateUser(user);
-        verify(mockBasicValidationService, times(1)).validateUser(user);
+    void shouldAcceptUser() {
+        assertDoesNotThrow(() -> validationService.validateUser(new User(11, "Ron", Status.ACTIVE)));
     }
 
     @Test
-    void validateUserShouldThrowIllegalArgumentExceptionIfTheUserIsInactive() {
+    void shouldThrowIllegalArgumentExceptionIfTheUserIsInactive() {
         User user = new User(11, "Ben", Status.INACTIVE);
-        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
-                () -> basicValidationService.validateUser(user));
-        assertEquals(exceptionThatWasThrown.getMessage(), "User with id " + user.getId() + " not in ACTIVE status");
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> validationService.validateUser(user))
+                .withMessage("User with id " + user.getId() + " not in ACTIVE status");
     }
 
     @Test
-    void validateMessageShouldCheckSuccessOfValidationOfMessage() {
-        mockBasicValidationService.validateMessage("hello");
-        verify(mockBasicValidationService, times(1)).validateMessage("hello");
+    void shouldAcceptTheMessage() {
+        assertDoesNotThrow(() -> validationService.validateMessage("Payment is complete"));
     }
 
     @Test
-    void validateMessageShouldThrowIllegalArgumentExceptionIfTheParameterIsNull() {
-        Throwable exceptionThatWasThrown = assertThrows(IllegalArgumentException.class,
-                () -> basicValidationService.validateMessage(null));
-        assertEquals(exceptionThatWasThrown.getMessage(), "Payment message must not be null");
+    void shouldThrowIllegalArgumentExceptionIfMessageIsNull() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> validationService.validateMessage(null))
+                .withMessage("Payment message must not be null");
     }
 }

--- a/src/test/java/com/endava/internship/mocking/service/BasicValidationServiceTest.java
+++ b/src/test/java/com/endava/internship/mocking/service/BasicValidationServiceTest.java
@@ -22,7 +22,7 @@ class BasicValidationServiceTest {
     }
 
     @Test
-    void shouldAcceptTheAmount() {
+    void shouldSuccessfullyValidateTheAmount() {
         assertDoesNotThrow(() -> validationService.validateAmount(55.00));
     }
 

--- a/src/test/java/com/endava/internship/mocking/service/PaymentServiceTest.java
+++ b/src/test/java/com/endava/internship/mocking/service/PaymentServiceTest.java
@@ -1,31 +1,112 @@
 package com.endava.internship.mocking.service;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.endava.internship.mocking.model.Payment;
+import com.endava.internship.mocking.model.Status;
+import com.endava.internship.mocking.model.User;
+import com.endava.internship.mocking.repository.PaymentRepository;
+import com.endava.internship.mocking.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentServiceTest {
 
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PaymentRepository paymentRepository;
+    @Mock
+    private ValidationService validationService;
+
+    User user;
+    Payment payment;
+    PaymentService paymentService;
 
     @BeforeEach
     void setUp() {
-
+        user = new User(11, "Ben", Status.ACTIVE);
+        payment = new Payment(11, 55.00, "Payed");
+        paymentService = new PaymentService(userRepository, paymentRepository, validationService);
     }
 
     @Test
-    void createPayment() {
+    void createPaymentShouldValidateServiceValidateUserIdAndAmount() {
+        when(userRepository.findById(11)).thenReturn(Optional.ofNullable(user));
+        validationService.validateUserId(11);
+        validationService.validateAmount(333.00);
+        validationService.validateUser(user);
 
+        verify(validationService).validateUserId(11);
+        verify(validationService).validateAmount(333.00);
+        when(userRepository.findById(11)).thenReturn(Optional.ofNullable(user));
+        verify(validationService).validateUser(user);
+
+        paymentService.createPayment(11, 333.00);
+
+        assertEquals(user, userRepository.findById(11).orElse(null));
     }
 
     @Test
-    void editMessage() {
+    void createPaymentShouldThrowNoSuchElementException() {
+        Throwable exceptionThatWasThrown = assertThrows(NoSuchElementException.class
+                , () -> paymentService.createPayment(11, 55.00));
+        assertEquals(exceptionThatWasThrown.getMessage(), "User with id " + 11 + " not found");
 
+        Throwable exceptionThatWasThrown1 = assertThrows(NoSuchElementException.class
+                , () -> paymentService.createPayment(22, 66.00));
+        assertNotEquals(exceptionThatWasThrown1.getMessage(), "User with id " + 11 + " not found");
+    }
+
+    @Captor
+    ArgumentCaptor<Payment> paymentArgumentCaptor;
+
+    @Test
+    void createPaymentShouldCheckUserIdAmountAndMessage() {
+        when(userRepository.findById(11)).thenReturn(Optional.ofNullable(user));
+        paymentService.createPayment(11, 333.00);
+        verify(paymentRepository).save(paymentArgumentCaptor.capture());
+
+        assertEquals(11, paymentArgumentCaptor.getValue().getUserId());
+        assertEquals(333.00, paymentArgumentCaptor.getValue().getAmount());
+        assertEquals("Payment from user Ben", paymentArgumentCaptor.getValue().getMessage());
+    }
+
+    @Test
+    void editPaymentMessageShouldReturnPaymentRepository() {
+        validationService.validatePaymentId(payment.getPaymentId());
+        validationService.validateMessage("NEW PAYMENT");
+
+        verify(validationService).validatePaymentId(payment.getPaymentId());
+        verify(validationService).validateMessage("NEW PAYMENT");
+
+        when(paymentRepository.editMessage(payment.getPaymentId()
+                , "The message was edited")).thenReturn(payment);
+        assertEquals(payment
+                , paymentService.editPaymentMessage(payment.getPaymentId()
+                        , "The message was edited"));
     }
 
     @Test
     void getAllByAmountExceeding() {
+        List<Payment> paymentList = new ArrayList<>();
+        paymentList.add(payment);
+        paymentList.add(payment);
+        paymentList.add(payment);
+        when(paymentRepository.findAll()).thenReturn(paymentList);
 
+        assertEquals(paymentList, paymentService.getAllByAmountExceeding(54.00));
+        assertNotEquals(paymentList, paymentService.getAllByAmountExceeding(56.00));
     }
 }

--- a/src/test/java/com/endava/internship/mocking/service/PaymentServiceTest.java
+++ b/src/test/java/com/endava/internship/mocking/service/PaymentServiceTest.java
@@ -1,5 +1,6 @@
 package com.endava.internship.mocking.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -13,6 +14,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -29,64 +32,105 @@ class PaymentServiceTest {
     private PaymentRepository paymentRepository;
     @Mock
     private ValidationService validationService;
+    @Captor
+    ArgumentCaptor<Payment> paymentArgumentCaptor;
 
     User user;
     Payment payment;
+    @InjectMocks
     PaymentService paymentService;
 
     @BeforeEach
     void setUp() {
         user = new User(11, "Ben", Status.ACTIVE);
         payment = new Payment(11, 55.00, "Payed");
-        paymentService = new PaymentService(userRepository, paymentRepository, validationService);
     }
 
     @Test
-    void createPaymentShouldThrowNoSuchElementException() {
-        when(userRepository.findById(11)).thenThrow(new NoSuchElementException("User with id 11 not found"));
+    void shouldThrowIllegalArgumentExceptionWhenuserIdIsNotValid() {
+        doThrow(new IllegalArgumentException("The user ID is not valid"))
+                .when(validationService).validateUserId(user.getId());
 
-        verify(validationService, never()).validateUser(user);
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> paymentService.createPayment(11, 333.00))
+                .withMessage("The user ID is not valid");
+    }
+
+    @Test
+    void shouldThrowIllegalArgumentExceptionWhenAmountIsNotValid() {
+        doNothing().when(validationService).validateUserId(user.getId());
+        doThrow(new IllegalArgumentException("The amount can not be negative"))
+                .when(validationService).validateAmount(-50.00);
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> paymentService.createPayment(11, -50.00))
+                .withMessage("The amount can not be negative");
+    }
+
+    @Test
+    void shouldThrowNoSuchElementExceptionWhenUserIsNotFoundInUserRepository() {
+        doNothing().when(validationService).validateUserId(22);
+        doNothing().when(validationService).validateAmount(333.00);
+
         assertThatExceptionOfType(NoSuchElementException.class)
-                .isThrownBy(() -> paymentService.createPayment(11, 55.00))
-                .withMessage("User with id 11 not found");
+                .isThrownBy(() -> paymentService.createPayment(22, 333.00))
+                .withMessage("User with id 22 not found");
     }
 
     @Test
-    void createPaymentShouldValidateIDAmountUserAndMessage() {
+    void shouldThrowNoSuchElementExceptionWhenUserIsNotActive() {
+        doNothing().when(validationService).validateUserId(22);
+        doNothing().when(validationService).validateAmount(333.00);
+        when(userRepository.findById(22)).thenReturn(Optional.of(user));
+        doThrow(new NoSuchElementException("This user is not active"))
+                .when(validationService).validateUser(user);
+
+        assertThatExceptionOfType(NoSuchElementException.class)
+                .isThrownBy(() -> paymentService.createPayment(22, 333.00))
+                .withMessage("This user is not active");
+    }
+
+    @Test
+    void shouldSuccessfulCreatePayment() {
+        doNothing().when(validationService).validateUserId(11);
+        doNothing().when(validationService).validateAmount(333.00);
         when(userRepository.findById(11)).thenReturn(Optional.of(user));
+        doNothing().when(validationService).validateUser(user);
+        when(paymentRepository.save(paymentArgumentCaptor.capture())).thenReturn(payment);
+
         paymentService.createPayment(11, 333.00);
-
-        ArgumentCaptor<Integer> argumentCaptorID = ArgumentCaptor.forClass(Integer.class);
-        ArgumentCaptor<Double> argumentCaptorAmount = ArgumentCaptor.forClass(Double.class);
-        ArgumentCaptor<User> argumentCaptorUser = ArgumentCaptor.forClass(User.class);
-        ArgumentCaptor<Payment> paymentArgumentCaptor = ArgumentCaptor.forClass(Payment.class);
-
-        verify(validationService).validateUserId(argumentCaptorID.capture());
-        verify(validationService).validateAmount(argumentCaptorAmount.capture());
-        verify(validationService).validateUser(argumentCaptorUser.capture());
-        verify(paymentRepository).save(paymentArgumentCaptor.capture());
 
         assertEquals(11, paymentArgumentCaptor.getValue().getUserId());
         assertEquals(333.00, paymentArgumentCaptor.getValue().getAmount());
         assertEquals("Payment from user Ben", paymentArgumentCaptor.getValue().getMessage());
+
+        verify(validationService).validateUserId(11);
+        verify(validationService).validateAmount(333.000);
+        verify(validationService).validateUser(user);
+        verify(paymentRepository).save(paymentArgumentCaptor.capture());
     }
 
     @Test
-    void editPaymentMessageShouldTheMEssageOfPayment() {
-        paymentService.editPaymentMessage(payment.getPaymentId(), "NEW");
+    void shouldEditPaymentMessage() {
+        Payment expectedPayment = Payment.copyOf(payment);
+        expectedPayment.setMessage("NEW");
 
-        ArgumentCaptor<UUID> argumentCaptorUUID = ArgumentCaptor.forClass(UUID.class);
-        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        doNothing().when(validationService).validatePaymentId(expectedPayment.getPaymentId());
+        doNothing().when(validationService).validateMessage("NEW");
+        when(paymentRepository.editMessage(payment.getPaymentId(), "NEW"))
+                .thenReturn(expectedPayment);
 
-        verify(validationService).validateMessage(argumentCaptor.capture());
-        verify(validationService).validatePaymentId(argumentCaptorUUID.capture());
-        verify(paymentRepository).editMessage(argumentCaptorUUID.capture()
-                , argumentCaptor.capture());
+        Payment actual = paymentService.editPaymentMessage(payment.getPaymentId(), "NEW");
+        assertThat(expectedPayment).isEqualTo(actual);
+
+        verify(validationService).validatePaymentId(payment.getPaymentId());
+        verify(validationService).validateMessage("NEW");
+        verify(paymentRepository).editMessage(payment.getPaymentId(), "NEW");
     }
 
     @Test
-    void getAllByAmountExceeding() {
-        List<Payment> actualPaymentList = new ArrayList<>();
+    void shouldGetAListOfWithExceedingAmount() {
+        List<Payment> paymentList = new ArrayList<>();
         List<Payment> expectedPaymentList = new ArrayList<>();
 
         Payment payment = new Payment(11, 56.00, "Payed");
@@ -95,18 +139,40 @@ class PaymentServiceTest {
         Payment payment3 = new Payment(11, 59.00, "Payed");
         Payment payment4 = new Payment(11, 60.00, "Payed");
 
-        actualPaymentList.add(payment);
-        actualPaymentList.add(payment1);
-        actualPaymentList.add(payment2);
-        actualPaymentList.add(payment3);
-        actualPaymentList.add(payment4);
+        paymentList.add(payment);
+        paymentList.add(payment1);
+        paymentList.add(payment2);
+        paymentList.add(payment3);
+        paymentList.add(payment4);
 
         expectedPaymentList.add(payment2);
         expectedPaymentList.add(payment3);
         expectedPaymentList.add(payment4);
 
-        when(paymentRepository.findAll()).thenReturn(actualPaymentList);
+        when(paymentRepository.findAll()).thenReturn(paymentList);
 
         assertEquals(expectedPaymentList, paymentService.getAllByAmountExceeding(57.00));
+    }
+
+    @Test
+    void shouldReturnAnEmptyListWhenNoPaymentWhichExceed() {
+        List<Payment> paymentList = new ArrayList<>();
+        List<Payment> expectedPaymentList = new ArrayList<>();
+
+        Payment payment = new Payment(11, 56.00, "Payed");
+        Payment payment1 = new Payment(11, 57.00, "Payed");
+        Payment payment2 = new Payment(11, 58.00, "Payed");
+        Payment payment3 = new Payment(11, 59.00, "Payed");
+        Payment payment4 = new Payment(11, 60.00, "Payed");
+
+        paymentList.add(payment);
+        paymentList.add(payment1);
+        paymentList.add(payment2);
+        paymentList.add(payment3);
+        paymentList.add(payment4);
+
+        when(paymentRepository.findAll()).thenReturn(paymentList);
+
+        assertEquals(expectedPaymentList, paymentService.getAllByAmountExceeding(100.00));
     }
 }

--- a/src/test/java/com/endava/internship/mocking/service/PaymentServiceTest.java
+++ b/src/test/java/com/endava/internship/mocking/service/PaymentServiceTest.java
@@ -54,6 +54,8 @@ class PaymentServiceTest {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> paymentService.createPayment(11, 333.00))
                 .withMessage("The user ID is not valid");
+
+        verify(validationService).validateUserId(11);
     }
 
     @Test
@@ -65,6 +67,9 @@ class PaymentServiceTest {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> paymentService.createPayment(11, -50.00))
                 .withMessage("The amount can not be negative");
+
+        verify(validationService).validateUserId(11);
+        verify(validationService).validateAmount(-50.000);
     }
 
     @Test
@@ -75,6 +80,9 @@ class PaymentServiceTest {
         assertThatExceptionOfType(NoSuchElementException.class)
                 .isThrownBy(() -> paymentService.createPayment(22, 333.00))
                 .withMessage("User with id 22 not found");
+
+        verify(validationService).validateUserId(22);
+        verify(validationService).validateAmount(333.000);
     }
 
     @Test
@@ -88,6 +96,9 @@ class PaymentServiceTest {
         assertThatExceptionOfType(NoSuchElementException.class)
                 .isThrownBy(() -> paymentService.createPayment(22, 333.00))
                 .withMessage("This user is not active");
+
+        verify(validationService).validateUserId(22);
+        verify(validationService).validateAmount(333.000);
     }
 
     @Test


### PR DESCRIPTION
Java Unit Testing with Mocking 
The Objective
You have acquired experience with unit testing using Junit as a unit testing framework and AssertJ for fluent assertions. Now it is time get a closer look on Mocking. When you are testing a class which is composed of colaborators to which it delegates some processing, it is necessary to mock these collaborators so that you can isolate the class being tested from the rest of your application. 

The Assignment
You will be writing unit tests for the classes BasicValidationService, InMemPaymentRepository, PaymentService. The most important one is PaymentService which has 3 collaborators:  UserRepository, PaymentRepository, ValidationService. All these collaborators are being injected into PaymentService as constructor parameters. You will be using Mockito to mock these collaborators in order to separate the behaviour of PaymentService from its collaborators. Remember, a Unit Test is always focused on a single class being tested. 

Homework Requirement

When testing the PaymentService, you are not just asserting the results it gives, but also verifying if it did the right calls to its collaborators. For example:

ValidationService does not return any values → you can use Mockito.verify() to check if a ValidationService method was called with the right arguments
PaymentRepository is more tricky however. You see, you have to validate that the correct Payment object was used to make the method call of PaymentRepository.save(Payment payment). Problem is that the Payment object was created inside the PaymentService, and it has a strongly, encapsulated UUID value. There is no way how to create another identical expected Payment object in the unit test for equality assertion because each new Payment instance will have a different UUID (and you cannot set it manually, the constructor for UUID is private). This is where you will do partial validation. Instead of Mockito.verify(), you will use the Argument captor and validate the other predictable values of Payment: userId, amount and message.
Discussion Topic
Please discuss with your mentor and share your throughts with him/her on the following questions:

Why does Payment class have a static factory method Payment.copyOf (Payment originalPayment)?  Why does InMemoryPaymentRepository uses this static factory method whenever possible instead of just returning the references to the Payment objects located within its encapsulated paymentMap?

Special Thanks 